### PR TITLE
Perf improvement: Binary search of matches

### DIFF
--- a/src/WatneyAstrometry.Core/QuadDb/CompactQuadDatabase.cs
+++ b/src/WatneyAstrometry.Core/QuadDb/CompactQuadDatabase.cs
@@ -25,6 +25,9 @@ namespace WatneyAstrometry.Core.QuadDb
         private ConcurrentDictionary<Guid, QuadDatabaseSolveInstanceMemoryCache> _contexts =
             new ConcurrentDictionary<Guid, QuadDatabaseSolveInstanceMemoryCache>();
 
+        /// <summary>
+        /// The directory where the .qdb files are located.
+        /// </summary>
         public string DatabaseDirectory { get; private set; }
 
         /// <summary>

--- a/src/WatneyAstrometry.Core/QuadDb/QuadDatabaseCellFile.cs
+++ b/src/WatneyAstrometry.Core/QuadDb/QuadDatabaseCellFile.cs
@@ -229,11 +229,30 @@ namespace WatneyAstrometry.Core.QuadDb
         private const float RatioMatchHigh = 1.0f + 0.011f; // 1.011
 
         /// <summary>
+        /// Returns the first index in <paramref name="arr"/> where R0 &gt;= <paramref name="value"/>
+        /// (standard lower_bound over a R0-sorted array).
+        /// </summary>
+        private static int LowerBound(ImageStarQuad[] arr, float value)
+        {
+            int left = 0, right = arr.Length;
+            while (left < right)
+            {
+                int mid = (left + right) >> 1;
+                if (arr[mid].Ratios.R0 < value)
+                    left = mid + 1;
+                else
+                    right = mid;
+            }
+            return left;
+        }
+
+        /// <summary>
         /// Read the bytes and spit out a quad.
         /// </summary>
         /// <param name="pBuf"></param>
         /// <param name="offset"></param>
         /// <param name="tentativeMatches">If given, we only return the constructed quad if the ratios match to one of the tentativeMatches image quads.
+        /// The array must be sorted ascending by R0 so that binary search can be used.
         /// Otherwise do no matching and just read the quad from the buffer and return it.</param>
         /// <param name="bytesNeedReversing">Flag that indicates if we need to reverse byte order because of endianness difference between DB file contents and the system</param>
         /// <returns></returns>
@@ -283,46 +302,40 @@ namespace WatneyAstrometry.Core.QuadDb
             var lo = ratios * RatioMatchLow;
             var hi = ratios * RatioMatchHigh;
 
-            for (var q = 0; q < tentativeMatches.Length; q++)
+            // Binary search into the R0-sorted array to skip the ~90% of quads outside the R0 window.
+            int startIdx = LowerBound(tentativeMatches, lo.R0);
+            for (var q = startIdx; q < tentativeMatches.Length; q++)
             {
                 var imgQuad = tentativeMatches[q];
-                if (imgQuad != null
-                    && imgQuad.Ratios.R0 >= lo.R0 && imgQuad.Ratios.R0 <= hi.R0
-                    && imgQuad.Ratios.R1 >= lo.R1 && imgQuad.Ratios.R1 <= hi.R1
-                    && imgQuad.Ratios.R2 >= lo.R2 && imgQuad.Ratios.R2 <= hi.R2
-                    && imgQuad.Ratios.R3 >= lo.R3 && imgQuad.Ratios.R3 <= hi.R3
-                    && imgQuad.Ratios.R4 >= lo.R4 && imgQuad.Ratios.R4 <= hi.R4
-                   )
+                if (imgQuad.Ratios.R0 > hi.R0) break; // past the R0 window; array is sorted
+                if (imgQuad.Ratios.R1 < lo.R1 || imgQuad.Ratios.R1 > hi.R1) continue;
+                if (imgQuad.Ratios.R2 < lo.R2 || imgQuad.Ratios.R2 > hi.R2) continue;
+                if (imgQuad.Ratios.R3 < lo.R3 || imgQuad.Ratios.R3 > hi.R3) continue;
+                if (imgQuad.Ratios.R4 < lo.R4 || imgQuad.Ratios.R4 > hi.R4) continue;
+                float ld, ra, dec;
+                if (bytesNeedReversing)
                 {
-                    float ld, ra, dec;
-                    if (bytesNeedReversing)
-                    {
-                        ld  = BitConverter.ToSingle(new byte[] { pFloats[3],  pFloats[2],  pFloats[1],  pFloats[0]  }, 0);
-                        ra  = BitConverter.ToSingle(new byte[] { pFloats[7],  pFloats[6],  pFloats[5],  pFloats[4]  }, 0);
-                        dec = BitConverter.ToSingle(new byte[] { pFloats[11], pFloats[10], pFloats[9],  pFloats[8]  }, 0);
-                    }
-                    else
-                    {
-                        // Note: On ARM, misaligned floats and doubles have to be read/written from memory as int/long and
-                        // converted to/from float/double via local variable that is guaranteed to be aligned.
-                        // https://github.com/dotnet/runtime/issues/18041
-                        // So we have to do this, otherwise ARMv7 breaks with "A datatype misalignment was detected in a load or store instruction."
-                        var if1 = *(int*)pFloats; pFloats += sizeof(int);
-                        var if2 = *(int*)pFloats; pFloats += sizeof(int);
-                        var if3 = *(int*)pFloats;
-                        ld  = *(float*)&if1;
-                        ra  = *(float*)&if2;
-                        dec = *(float*)&if3;
-                    }
-
-                    return new StarQuad(ratios, ld, new EquatorialCoords(ra, dec));
+                    ld  = BitConverter.ToSingle(new byte[] { pFloats[3],  pFloats[2],  pFloats[1],  pFloats[0]  }, 0);
+                    ra  = BitConverter.ToSingle(new byte[] { pFloats[7],  pFloats[6],  pFloats[5],  pFloats[4]  }, 0);
+                    dec = BitConverter.ToSingle(new byte[] { pFloats[11], pFloats[10], pFloats[9],  pFloats[8]  }, 0);
                 }
+                else
+                {
+                    // Note: On ARM, misaligned floats and doubles have to be read/written from memory as int/long and
+                    // converted to/from float/double via local variable that is guaranteed to be aligned.
+                    // https://github.com/dotnet/runtime/issues/18041
+                    // So we have to do this, otherwise ARMv7 breaks with "A datatype misalignment was detected in a load or store instruction."
+                    var if1 = *(int*)pFloats; pFloats += sizeof(int);
+                    var if2 = *(int*)pFloats; pFloats += sizeof(int);
+                    var if3 = *(int*)pFloats;
+                    ld  = *(float*)&if1;
+                    ra  = *(float*)&if2;
+                    dec = *(float*)&if3;
+                }
+                return new StarQuad(ratios, ld, new EquatorialCoords(ra, dec));
             }
 
             return null;
-
-              
-            
         }
 
         public void Dispose()

--- a/src/WatneyAstrometry.Core/QuadDb/QuadDatabaseCellFile.cs
+++ b/src/WatneyAstrometry.Core/QuadDb/QuadDatabaseCellFile.cs
@@ -65,9 +65,14 @@ namespace WatneyAstrometry.Core.QuadDb
             var subCellsInRangeIndexesArr = new int[pass.SubCells.Length];
             var subCellsInRangeLen = 0;
 
+            var decThreshold = angularDistance + pass.AvgSubCellRadius;
             for (var p = 0; p < pass.SubCells.Length; p++)
             {
                 var subCell = pass.SubCells[p];
+                // Fast Dec pre-filter: Dec difference is always <= great-circle distance,
+                // so if it already exceeds the threshold the full check can't pass.
+                if (Math.Abs(subCell.Center.Dec - center.Dec) >= decThreshold)
+                    continue;
                 if (subCell.Center.GetAngularDistanceTo(center) - pass.AvgSubCellRadius < angularDistance)
                 {
                     subCellsInRangeArr[subCellsInRangeLen] = subCell;

--- a/src/WatneyAstrometry.Core/QuadDb/QuadDatabaseCellFile.cs
+++ b/src/WatneyAstrometry.Core/QuadDb/QuadDatabaseCellFile.cs
@@ -85,9 +85,6 @@ namespace WatneyAstrometry.Core.QuadDb
             var thisFileCache = cache.Files[_fileId];
             FileStream fileStream = null;
 
-            // Pre-allocate, so that we don't need to allocate later down the road.
-            var quadDataArray = new float[8];
-
             for (var sc = 0; sc < subCellsInRangeLen; sc++)
             {
                 var subCellIdx = subCellsInRangeIndexesArr[sc];
@@ -192,7 +189,7 @@ namespace WatneyAstrometry.Core.QuadDb
                         advance = startIndex * QuadDataLen;
                         for (var q = startIndex; q < nextStartIndex; q++)
                         {
-                            var quad = BytesToQuadNew(pSubCellDataBytes, advance, imageQuads, _bytesNeedReversing, quadDataArray);
+                            var quad = BytesToQuadNew(pSubCellDataBytes, advance, imageQuads, _bytesNeedReversing);
                             
                             if (quad != null)
                                 matchingQuads.Add(quad);
@@ -228,6 +225,8 @@ namespace WatneyAstrometry.Core.QuadDb
 
         private const float OnePer1023 = 0.0009775171065493f; // (1 / 1023)
         private const float OnePer511 = 0.001956947162f; // (1 / 511)
+        private const float RatioMatchLow  = 1.0f - 0.011f; // 0.989
+        private const float RatioMatchHigh = 1.0f + 0.011f; // 1.011
 
         /// <summary>
         /// Read the bytes and spit out a quad.
@@ -237,40 +236,31 @@ namespace WatneyAstrometry.Core.QuadDb
         /// <param name="tentativeMatches">If given, we only return the constructed quad if the ratios match to one of the tentativeMatches image quads.
         /// Otherwise do no matching and just read the quad from the buffer and return it.</param>
         /// <param name="bytesNeedReversing">Flag that indicates if we need to reverse byte order because of endianness difference between DB file contents and the system</param>
-        /// <param name="quadDataArray"></param>
         /// <returns></returns>
-        private static unsafe StarQuad BytesToQuadNew(byte* pBuf, int offset, ImageStarQuad[] tentativeMatches, bool bytesNeedReversing, float[] quadDataArray)
+        private static unsafe StarQuad BytesToQuadNew(byte* pBuf, int offset, ImageStarQuad[] tentativeMatches, bool bytesNeedReversing)
         {
-
             bool noMatching = tentativeMatches == null;
             byte* pRatios = (byte*)(pBuf + offset);
             byte* pFloats = (byte*)(pBuf + offset + 6); // floats come after the ratios
 
             // Ratios are packed; 3x 10 bit numbers, 2x 9 bit numbers.
-            quadDataArray[0] = (((pRatios[1] << 8) & 0x3FF) + ((pRatios[0]) & 0x3FF)) * OnePer1023;
-            quadDataArray[1] = ((((pRatios[2] & 0x0F) << 6) & 0x3FF) + ((pRatios[1] >> 2) & 0x3FF)) * OnePer1023;
-            quadDataArray[2] = ((((pRatios[3] & 0x3F) << 4) & 0x3FF) + ((pRatios[2] >> 4) & 0x3FF)) * OnePer1023;
-            quadDataArray[3] = ((((pRatios[4] & 0x7F) << 2) & 0x1FF) + ((pRatios[3] >> 6) & 0x1FF)) * OnePer511;
-            quadDataArray[4] = ((((pRatios[5]) << 1) & 0x1FF) + ((pRatios[4] >> 7) & 0x1FF)) * OnePer511;
-
+            float r0 = (((pRatios[1] << 8) & 0x3FF) + ((pRatios[0]) & 0x3FF)) * OnePer1023;
+            float r1 = ((((pRatios[2] & 0x0F) << 6) & 0x3FF) + ((pRatios[1] >> 2) & 0x3FF)) * OnePer1023;
+            float r2 = ((((pRatios[3] & 0x3F) << 4) & 0x3FF) + ((pRatios[2] >> 4) & 0x3FF)) * OnePer1023;
+            float r3 = ((((pRatios[4] & 0x7F) << 2) & 0x1FF) + ((pRatios[3] >> 6) & 0x1FF)) * OnePer511;
+            float r4 = ((((pRatios[5]) << 1) & 0x1FF) + ((pRatios[4] >> 7) & 0x1FF)) * OnePer511;
 
             if (noMatching)
             {
                 // Ratios are always written in little endian and since we read byte by byte, endianness doesn't matter here.
 
                 // Floats were written in whichever endianness the database was written in.
+                float ld, ra, dec;
                 if (bytesNeedReversing)
                 {
-                    // largestDist
-                    quadDataArray[5] = BitConverter.ToSingle(
-                    new byte[] { pFloats[3], pFloats[2], pFloats[1], pFloats[0] }, 0);
-                    // ra
-                    quadDataArray[6] = BitConverter.ToSingle(
-                        new byte[] { pFloats[7], pFloats[6], pFloats[5], pFloats[4] }, 0);
-                    // dec
-                    quadDataArray[7] = BitConverter.ToSingle(
-                        new byte[] { pFloats[11], pFloats[10], pFloats[9], pFloats[8] }, 0);
-                    
+                    ld  = BitConverter.ToSingle(new byte[] { pFloats[3],  pFloats[2],  pFloats[1],  pFloats[0]  }, 0);
+                    ra  = BitConverter.ToSingle(new byte[] { pFloats[7],  pFloats[6],  pFloats[5],  pFloats[4]  }, 0);
+                    dec = BitConverter.ToSingle(new byte[] { pFloats[11], pFloats[10], pFloats[9],  pFloats[8]  }, 0);
                 }
                 else
                 {
@@ -278,52 +268,38 @@ namespace WatneyAstrometry.Core.QuadDb
                     // converted to/from float/double via local variable that is guaranteed to be aligned.
                     // https://github.com/dotnet/runtime/issues/18041
                     // So we have to do this, otherwise ARMv7 breaks with "A datatype misalignment was detected in a load or store instruction."
-
-                    var if1 = *(int*)pFloats;
-                    pFloats += sizeof(int);
-                    var if2 = *(int*)pFloats;
-                    pFloats += sizeof(int);
+                    var if1 = *(int*)pFloats; pFloats += sizeof(int);
+                    var if2 = *(int*)pFloats; pFloats += sizeof(int);
                     var if3 = *(int*)pFloats;
-
-                    quadDataArray[5] = *(float*)&if1; // largestDist
-                    quadDataArray[6] = *(float*)&if2; // ra
-                    quadDataArray[7] = *(float*)&if3; // dec
+                    ld  = *(float*)&if1;
+                    ra  = *(float*)&if2;
+                    dec = *(float*)&if3;
                 }
 
-                // Need to allocate a new instance so that all quads don't refer to the same pre-allocated array instance...
-                var ratios = new float[]
-                {
-                    quadDataArray[0],
-                    quadDataArray[1],
-                    quadDataArray[2],
-                    quadDataArray[3],
-                    quadDataArray[4]
-                };
-                var quad = new StarQuad(ratios, quadDataArray[5], new EquatorialCoords(quadDataArray[6], quadDataArray[7]));
-                return quad;
+                return new StarQuad(new QuadRatios(r0, r1, r2, r3, r4), ld, new EquatorialCoords(ra, dec));
             }
+
+            var ratios = new QuadRatios(r0, r1, r2, r3, r4);
+            var lo = ratios * RatioMatchLow;
+            var hi = ratios * RatioMatchHigh;
 
             for (var q = 0; q < tentativeMatches.Length; q++)
             {
-                
                 var imgQuad = tentativeMatches[q];
-                
                 if (imgQuad != null
-                    && Math.Abs(imgQuad.Ratios[0] / quadDataArray[0] - 1.0f) <= 0.011f
-                    && Math.Abs(imgQuad.Ratios[1] / quadDataArray[1] - 1.0f) <= 0.011f
-                    && Math.Abs(imgQuad.Ratios[2] / quadDataArray[2] - 1.0f) <= 0.011f
-                    && Math.Abs(imgQuad.Ratios[3] / quadDataArray[3] - 1.0f) <= 0.011f
-                    && Math.Abs(imgQuad.Ratios[4] / quadDataArray[4] - 1.0f) <= 0.011f
+                    && imgQuad.Ratios.R0 >= lo.R0 && imgQuad.Ratios.R0 <= hi.R0
+                    && imgQuad.Ratios.R1 >= lo.R1 && imgQuad.Ratios.R1 <= hi.R1
+                    && imgQuad.Ratios.R2 >= lo.R2 && imgQuad.Ratios.R2 <= hi.R2
+                    && imgQuad.Ratios.R3 >= lo.R3 && imgQuad.Ratios.R3 <= hi.R3
+                    && imgQuad.Ratios.R4 >= lo.R4 && imgQuad.Ratios.R4 <= hi.R4
                    )
                 {
+                    float ld, ra, dec;
                     if (bytesNeedReversing)
                     {
-                        quadDataArray[5] = BitConverter.ToSingle(
-                            new byte[] { pFloats[3], pFloats[2], pFloats[1], pFloats[0] }, 0);
-                        quadDataArray[6] = BitConverter.ToSingle(
-                            new byte[] { pFloats[7], pFloats[6], pFloats[5], pFloats[4] }, 0);
-                        quadDataArray[7] = BitConverter.ToSingle(
-                            new byte[] { pFloats[11], pFloats[10], pFloats[9], pFloats[8] }, 0);
+                        ld  = BitConverter.ToSingle(new byte[] { pFloats[3],  pFloats[2],  pFloats[1],  pFloats[0]  }, 0);
+                        ra  = BitConverter.ToSingle(new byte[] { pFloats[7],  pFloats[6],  pFloats[5],  pFloats[4]  }, 0);
+                        dec = BitConverter.ToSingle(new byte[] { pFloats[11], pFloats[10], pFloats[9],  pFloats[8]  }, 0);
                     }
                     else
                     {
@@ -331,31 +307,16 @@ namespace WatneyAstrometry.Core.QuadDb
                         // converted to/from float/double via local variable that is guaranteed to be aligned.
                         // https://github.com/dotnet/runtime/issues/18041
                         // So we have to do this, otherwise ARMv7 breaks with "A datatype misalignment was detected in a load or store instruction."
-
-                        var if1 = *(int*)pFloats;
-                        pFloats += sizeof(int);
-                        var if2 = *(int*)pFloats; 
-                        pFloats += sizeof(int);
+                        var if1 = *(int*)pFloats; pFloats += sizeof(int);
+                        var if2 = *(int*)pFloats; pFloats += sizeof(int);
                         var if3 = *(int*)pFloats;
-
-                        quadDataArray[5] = *(float*)&if1; // largestDist
-                        quadDataArray[6] = *(float*)&if2; // ra
-                        quadDataArray[7] = *(float*)&if3; // dec
+                        ld  = *(float*)&if1;
+                        ra  = *(float*)&if2;
+                        dec = *(float*)&if3;
                     }
 
-                    // Need to allocate a new instance so that all quads don't refer to the same pre-allocated array instance...
-                    var ratios = new float[]
-                    {
-                        quadDataArray[0], 
-                        quadDataArray[1], 
-                        quadDataArray[2], 
-                        quadDataArray[3], 
-                        quadDataArray[4]
-                    };
-                    var quad = new StarQuad(ratios, quadDataArray[5], new EquatorialCoords(quadDataArray[6], quadDataArray[7]));
-                    return quad;
+                    return new StarQuad(ratios, ld, new EquatorialCoords(ra, dec));
                 }
-
             }
 
             return null;

--- a/src/WatneyAstrometry.Core/Solver.cs
+++ b/src/WatneyAstrometry.Core/Solver.cs
@@ -1195,15 +1195,15 @@ namespace WatneyAstrometry.Core
                     if (imageQuad == null) return;
                     for (var j = 0; j < dbQuads.Count; j++)
                     {
-                        var d1 = Math.Abs(imageQuad.Ratios[0] / dbQuads[j].Ratios[0] - 1.0);
+                        var d1 = Math.Abs(imageQuad.Ratios.R0 / dbQuads[j].Ratios.R0 - 1.0);
                         if (d1 > threshold) continue;
-                        var d2 = Math.Abs(imageQuad.Ratios[1] / dbQuads[j].Ratios[1] - 1.0);
+                        var d2 = Math.Abs(imageQuad.Ratios.R1 / dbQuads[j].Ratios.R1 - 1.0);
                         if (d2 > threshold) continue;
-                        var d3 = Math.Abs(imageQuad.Ratios[2] / dbQuads[j].Ratios[2] - 1.0);
+                        var d3 = Math.Abs(imageQuad.Ratios.R2 / dbQuads[j].Ratios.R2 - 1.0);
                         if (d3 > threshold) continue;
-                        var d4 = Math.Abs(imageQuad.Ratios[3] / dbQuads[j].Ratios[3] - 1.0);
+                        var d4 = Math.Abs(imageQuad.Ratios.R3 / dbQuads[j].Ratios.R3 - 1.0);
                         if (d4 > threshold) continue;
-                        var d5 = Math.Abs(imageQuad.Ratios[4] / dbQuads[j].Ratios[4] - 1.0);
+                        var d5 = Math.Abs(imageQuad.Ratios.R4 / dbQuads[j].Ratios.R4 - 1.0);
                         if (d5 > threshold) continue;
                         
                         matches.Add(new StarQuadMatch(dbQuads[j], imageQuad));
@@ -1361,10 +1361,6 @@ namespace WatneyAstrometry.Core
                     var largestDistance = sixDistances.Max();
 
                     sixDistances.RemoveAt(sixDistances.IndexOf(largestDistance));
-                    var ratios = sixDistances
-                        .Select(x => (float)(x / largestDistance))
-                        .ToArray();
-                    
                     var quadStars = new ImageStar[]
                     {
                         stars[starIndex0],
@@ -1373,7 +1369,14 @@ namespace WatneyAstrometry.Core
                         stars[starIndexC]
                     };
 
-                    var quad = new ImageStarQuad(ratios, (float)largestDistance, quadStars);
+                    var quad = new ImageStarQuad(
+                        new QuadRatios(
+                            (float)(sixDistances[0] / largestDistance),
+                            (float)(sixDistances[1] / largestDistance),
+                            (float)(sixDistances[2] / largestDistance),
+                            (float)(sixDistances[3] / largestDistance),
+                            (float)(sixDistances[4] / largestDistance)),
+                        (float)largestDistance, quadStars);
                     quads.Add(quad);
                 }
 

--- a/src/WatneyAstrometry.Core/Solver.cs
+++ b/src/WatneyAstrometry.Core/Solver.cs
@@ -350,7 +350,9 @@ namespace WatneyAstrometry.Core
             OnSolveProgress?.Invoke(SolverStep.QuadFormationStarted);
 
             // Form quads from image stars
-            var (imageStarQuads, countInFirstPass) = FormImageStarQuads(chosenDetectedStars.ToList()); 
+            var (imageStarQuads, countInFirstPass) = FormImageStarQuads(chosenDetectedStars.ToList());
+            // Sort by R0 once so BytesToQuadNew can binary-search into this array.
+            Array.Sort(imageStarQuads, (a, b) => a.Ratios.R0.CompareTo(b.Ratios.R0));
             _logger.WriteInfo($"Formed {imageStarQuads.Length} quads from the chosen stars");
 
             OnSolveProgress?.Invoke(SolverStep.QuadFormationFinished);

--- a/src/WatneyAstrometry.Core/Types/EquatorialCoords.cs
+++ b/src/WatneyAstrometry.Core/Types/EquatorialCoords.cs
@@ -18,14 +18,35 @@ namespace WatneyAstrometry.Core.Types
     /// </summary>
     public class EquatorialCoords
     {
+        private double dec;
+        private double decRad;
+        private double ra;
+        private double raRad;
+
         /// <summary>
         /// RA coordinate, degrees decimal number.
         /// </summary>
-        public double Ra { get; set; }
+        public double Ra
+        {
+            get => ra;
+            set
+            {
+                ra = value;
+                raRad = Conversions.Deg2Rad(ra);
+            }
+        }
         /// <summary>
         /// Dec coordinate, degrees decimal number.
         /// </summary>
-        public double Dec { get; set; }
+        public double Dec
+        {
+            get => dec;
+            set
+            {
+                dec = value;
+                decRad = Conversions.Deg2Rad(dec);
+            }
+        }
 
         /// <summary>
         /// New empty equatorialcoords.
@@ -118,13 +139,12 @@ namespace WatneyAstrometry.Core.Types
         /// <returns>Distance between the points in degrees</returns>
         public static double GetAngularDistanceBetween(EquatorialCoords p1, EquatorialCoords p2)
         {
-            var a = Math.Sin(Conversions.Deg2Rad(p1.Dec)) * Math.Sin(Conversions.Deg2Rad(p2.Dec)) +
-                    Math.Cos(Conversions.Deg2Rad(p1.Dec)) * Math.Cos(Conversions.Deg2Rad(p2.Dec)) *
-                    Math.Cos(Conversions.Deg2Rad(p1.Ra) - Conversions.Deg2Rad(p2.Ra));
+            var a = Math.Sin(p1.decRad) * Math.Sin(p2.decRad) +
+                    Math.Cos(p1.decRad) * Math.Cos(p2.decRad) *
+                    Math.Cos(p1.raRad - p2.raRad);
             var angle = Math.Acos(a);
             return Conversions.Rad2Deg(angle);
-        }
-        
+        }        
 
         /// <summary>
         /// Transforms the RA, Dec coords to standard coordinates around the given center.
@@ -133,11 +153,9 @@ namespace WatneyAstrometry.Core.Types
         /// <returns></returns>
         public (double x, double y) ToStandardCoordinates(EquatorialCoords center)
         {
-            var centerRaRad = Conversions.Deg2Rad(center.Ra);
-            var centerDecRad = Conversions.Deg2Rad(center.Dec);
-            var raRad = Conversions.Deg2Rad(Ra);
-            var decRad = Conversions.Deg2Rad(Dec);
-
+            var centerRaRad = center.raRad;
+            var centerDecRad = center.decRad;
+             
             var divider = (Math.Cos(centerDecRad) * Math.Cos(decRad) * Math.Cos(raRad - centerRaRad) +
                            Math.Sin(centerDecRad) * Math.Sin(decRad));
 
@@ -159,8 +177,8 @@ namespace WatneyAstrometry.Core.Types
         public static EquatorialCoords StandardToEquatorial(EquatorialCoords center, double stdX, double stdY)
         {
             // TODO: add the source for the equations
-            var cpRa = Conversions.Deg2Rad(center.Ra);
-            var cpDec = Conversions.Deg2Rad(center.Dec);
+            var cpRa = center.raRad;
+            var cpDec = center.decRad;
 
             var ra = cpRa + Math.Atan2(-stdX, (Math.Cos(cpDec) - stdY * Math.Sin(cpDec)));
             var dec = Math.Asin(
@@ -183,8 +201,8 @@ namespace WatneyAstrometry.Core.Types
         {
             // Calculations from the book: ISBN 0-935702-68-7, Explanatory Supplement to the Astronomical Almanac
 
-            var alpha = Conversions.Deg2Rad(coordinates.Ra);
-            var delta = Conversions.Deg2Rad(coordinates.Dec);
+            var alpha = coordinates.raRad;
+            var delta = coordinates.decRad;
 
             // double julianCenturyDays = 36525;
             double j2000JulianDays = 2451545.0;
@@ -243,8 +261,8 @@ namespace WatneyAstrometry.Core.Types
 
             for (var i = 0; i < coords.Count; i++)
             {
-                var raRad = Conversions.Deg2Rad(coords[i].Ra);
-                var decRad = Conversions.Deg2Rad(coords[i].Dec);
+                var raRad = coords[i].raRad;
+                var decRad = coords[i].decRad;
 
                 x += Math.Cos(decRad) * Math.Cos(raRad);
                 y += Math.Cos(decRad) * Math.Sin(raRad);
@@ -285,19 +303,19 @@ namespace WatneyAstrometry.Core.Types
             var pixelsPerRadW = imageWidth / imageWidthRad;
             var pixelsPerRadH = imageHeight / imageHeightRad;
 
-            double theta = -rotationDeg; // CCW
+            double thetaRad = -Conversions.Deg2Rad(rotationDeg); // CCW
 
-            var pa = pixelsPerRadW * Math.Cos(Conversions.Deg2Rad(theta));
-            var pb = pixelsPerRadH * Math.Sin(Conversions.Deg2Rad(theta));
-            var pd = pixelsPerRadW * -Math.Sin(Conversions.Deg2Rad(theta));
-            var pe = pixelsPerRadH * Math.Cos(Conversions.Deg2Rad(theta));
+            var pa = pixelsPerRadW * Math.Cos(thetaRad);
+            var pb = pixelsPerRadH * Math.Sin(thetaRad);
+            var pd = pixelsPerRadW * -Math.Sin(thetaRad);
+            var pe = pixelsPerRadH * Math.Cos(thetaRad);
             var pc = imageWidth / 2.0;
             var pf = imageHeight / 2.0;
 
-            var starRaRad = Conversions.Deg2Rad(coordinate.Ra);
-            var starDecRad = Conversions.Deg2Rad(coordinate.Dec);
-            var centerRaRad = Conversions.Deg2Rad(planeCenter.Ra);
-            var centerDecRad = Conversions.Deg2Rad(planeCenter.Dec);
+            var starRaRad = coordinate.raRad;
+            var starDecRad = coordinate.decRad;
+            var centerRaRad = planeCenter.raRad;
+            var centerDecRad = planeCenter.decRad;
 
             var starX = Math.Cos(starDecRad) * Math.Sin(starRaRad - centerRaRad) /
                         (Math.Cos(centerDecRad) * Math.Cos(starDecRad) * Math.Cos(starRaRad - centerRaRad) + Math.Sin(centerDecRad) * Math.Sin(starDecRad));

--- a/src/WatneyAstrometry.Core/Types/ImageStarQuad.cs
+++ b/src/WatneyAstrometry.Core/Types/ImageStarQuad.cs
@@ -32,7 +32,7 @@ namespace WatneyAstrometry.Core.Types
         /// <param name="largestDistance"></param>
         /// <param name="stars"></param>
         /// <exception cref="Exception"></exception>
-        public ImageStarQuad(float[] ratios, float largestDistance, IList<ImageStar> stars)
+        public ImageStarQuad(QuadRatios ratios, float largestDistance, IList<ImageStar> stars)
             : base(ratios, largestDistance, null)
         {
             if (stars.Count != 4)

--- a/src/WatneyAstrometry.Core/Types/QuadRatios.cs
+++ b/src/WatneyAstrometry.Core/Types/QuadRatios.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Jussi Saarivirta.
+// Licensed under the Apache License, Version 2.0.
+
+namespace WatneyAstrometry.Core.Types
+{
+    /// <summary>
+    /// The five distance ratios that define a star quad, stored as a value type
+    /// to avoid heap allocation and pointer indirection on the hot matching path.
+    /// </summary>
+    public readonly struct QuadRatios
+    {
+        public readonly float R0;
+        public readonly float R1;
+        public readonly float R2;
+        public readonly float R3;
+        public readonly float R4;
+
+        public QuadRatios(float r0, float r1, float r2, float r3, float r4)
+        {
+            R0 = r0; R1 = r1; R2 = r2; R3 = r3; R4 = r4;
+        }
+
+        /// <summary>
+        /// Indexer for non-performance-critical access (equality comparers, visualizers).
+        /// Use the R0–R4 fields directly in hot paths to avoid the branch.
+        /// </summary>
+        public float this[int i]
+        {
+            get
+            {
+                switch (i)
+                {
+                    case 0: return R0;
+                    case 1: return R1;
+                    case 2: return R2;
+                    case 3: return R3;
+                    default: return R4;
+                }
+            }
+        }
+
+        public static QuadRatios operator *(QuadRatios q, float f) =>
+            new QuadRatios(q.R0 * f, q.R1 * f, q.R2 * f, q.R3 * f, q.R4 * f);
+    }
+}

--- a/src/WatneyAstrometry.Core/Types/StarQuad.cs
+++ b/src/WatneyAstrometry.Core/Types/StarQuad.cs
@@ -15,7 +15,7 @@ namespace WatneyAstrometry.Core.Types
         /// <summary>
         /// The quad ratios (between stars).
         /// </summary>
-        public float[] Ratios { get; protected set; }
+        public QuadRatios Ratios { get; protected set; }
         /// <summary>
         /// The largest distance (degrees or pixels).
         /// </summary>
@@ -36,7 +36,7 @@ namespace WatneyAstrometry.Core.Types
         /// <param name="largestDistance"></param>
         /// <param name="midPoint"></param>
         /// <param name="stars"></param>
-        public StarQuad(float[] ratios, float largestDistance, EquatorialCoords midPoint, IList<IStar> stars = null)
+        public StarQuad(QuadRatios ratios, float largestDistance, EquatorialCoords midPoint, IList<IStar> stars = null)
         {
             //if (ratios.Length != 5)
             //    throw new Exception("Five ratios form a quad");


### PR DESCRIPTION
Thanks for this great work in a language I can work with.
For my intended use case (alt/az mounted telescope calibration) faster blind matches would help, so I did a profiling pass for hotspots.
 ## This PR
Though I could not find the benchmark images to reproduce/correlate your results, for my single test picture this is a reduction in a blind SOLVE_DURATION of 1.96 seconds to 1.34 seconds on my puny laptop.
I see you have a `net10` branch that also upgraded to a sorted tentative match list, so that dovetails nicely with the biggest improvement here:
* instead of a linear search, do a binary search of the quad from the db in the (now sorted) tentative image match list based on R0 first as this already eliminates 90%+ of the compares.
Other improvements:
* Eliminate heap allocations of arrays (and thereby gen0 sweeps) for the 5 ratios by using a struct instead of array
* Compare using a multiplication instead of division
* Store rads along with the degrees in a `HorizontalCoordinate` to avoid multiple dec/rad conversions.

 ## Future improvements
Also, I'd like some feedback on the following proposal:
Currently, the matching process is mostly I/O+memory bound, not so much CPU bound.
Database files have a quad as 6 bytes ratios (packed floats) + 12 bytes metadata (ra, dec, longest distance).
This metadata is only used on a match as far as I can see, which is (in my test scenario) 0.0005%. This means that most of the time, the 12 bytes are never read and essentially wasting 67% of the available bandwidth (disk, cache lines etc). A 2x speedup vs the current baseline may be very well possible with a database layout that stores the metadata separate from the ratios, for example in a separate file or at the end of the current file.
Also, if the quads in the subcell are also stored ordered by R0, we can do a merge join (zipper) with the tentative image quads for even more algorithmic efficiency: baseline is `O(N_db * M_img)`, this PR improves to `O(N * log(M))`, merge join would be `O(N + M)` but it's still I/O limited so don't expect to gain more than ~5% from this. But, it is low hanging fruit when you're rebuilding the db anyway.
This has a high impact, basically completely rebuilding the db in a non-backwards-compatible manner, so before embarking on this journey I'd like your opinion :)

It could also be that my simple test scenario is not representative, so it would be nice to have benchmark images or another public benchmark set.